### PR TITLE
*args

### DIFF
--- a/public/config/operators.json
+++ b/public/config/operators.json
@@ -13,6 +13,8 @@
      "symbol": "@"},
     {"name": "splat",
      "symbol": "*"},
+    {"name": "starargs",
+     "symbol": "*args"},
     {"name": "tilde",
      "symbol": "~"},
     {"name": "octothorpe",


### PR DESCRIPTION
While I understand the historical/canonical use of "splat" I'd argue that the programming world rather be using "star" instead.

Ex. Google Trends - popularity of "\* splat" searches vs "\* star" searches in the programming category from 2004 onward.
http://www.google.com/trends/explore#cat=0-5-31&q=*%20splat%2C%20*%20star&cmpt=q

I know it's convention. But language evolves and I think this is a movement in the right direction. 

What sounds better to you?

stargs
or 
splargs

stararray
or
splarray

I thought we'd start small by just introducing the idea of "starargs/*args" and move from there.

Anyway, just a suggestion, and one that's probably outside of the scope of this project, since *args technically isn't an operator. 

Cheers,

Will
