### PR TITLE
Add example for <=> operator

### DIFF
--- a/app/config/operators.js
+++ b/app/config/operators.js
@@ -6,7 +6,8 @@ module.exports = [
     },
     {
         "name": "spaceship",
-        "symbol": "<=>"
+        "symbol": "<=>",
+        "example": "# Compares two objects, mostly used to implement the Comparable module.\nclass Exam\n  include Comparable\n\n  def <=>(other)\n    self.score <=> other.score\n  end\nend\n\n> Exam.new(score: 100) > Exam.new(score: 50)\ntrue\n> [ Exam.new(score: 60), Exam.new(score: 10), Exam.new(score: 30) ].sort\n[<Exam score: 10>, <Exam score: 30>, <Exam score: 60>]\n"
     },
     {
         "name": "threequals",


### PR DESCRIPTION
Adds an example for `Comparable` in the `<=>` spaceship operator.

http://ruby-doc.org/core-1.9.3/Comparable.html

<img width="1091" alt="screen shot 2015-09-08 at 10 27 10 pm" src="https://cloud.githubusercontent.com/assets/84159/9751927/c65bbe3c-5678-11e5-8ea7-51102d74bbfc.png">
