### PR TITLE
Add examples equallike and threequals

### DIFF
--- a/app/config/operators.js
+++ b/app/config/operators.js
@@ -11,7 +11,8 @@ module.exports = [
     },
     {
         "name": "threequals",
-        "symbol": "==="
+        "symbol": "===",
+        "example": "# Case match\nclass Icecream\n  attr_accessor :flavour\n\n  def initialize(flavour)\n    @flavour = flavour\n  end\n\n  def ===(another_icecream)\n    @flavour == another_icecream.flavour\n  end\nend\n\nvanilla_icecream = Icecream.new 'vanilla'\n\ncase vanilla_icecream\nwhen (Icecream.new 'chocolate')\n  puts \"Yikes!\"\nwhen (Icecream.new 'cookies and cream')\n  puts \"Yikes!\"\nwhen (Icecream.new 'vanilla')\n  puts \"Yiiiiis!\"\nend\n# => \"Yiiiiis!\""
     },
     {
         "name": "twiddle wakka",

--- a/app/config/operators.js
+++ b/app/config/operators.js
@@ -83,7 +83,8 @@ module.exports = [
     },
     {
         "name": "equalike",
-        "symbol": "=~"
+        "symbol": "=~",
+        "example": "# Pattern match\n# Used in String to match a Regular Expression\n> \"hello world\" =~ /hello/\n0\n> \"hello world\" =~ /hi/\nnil\n\n# Also used in Regexp to match a string\n> /hello/ =~ \"hello world\"\n0\n> /hello/ =~ \"bacon\"\nnil\n"
     },
     {
         "name": "hat",

--- a/app/config/operators.js
+++ b/app/config/operators.js
@@ -85,7 +85,7 @@ module.exports = [
     {
         "name": "equalike",
         "symbol": "=~",
-        "example": "# Pattern match\n# Used in String to match a Regular Expression\n> \"hello world\" =~ /hello/\n0\n> \"hello world\" =~ /hi/\nnil\n\n# Also used in Regexp to match a string\n> /hello/ =~ \"hello world\"\n0\n> /hello/ =~ \"bacon\"\nnil\n"
+        "example": "# Pattern matching\n# Used in String to match a Regular Expression (Regexp)\n\"hello world\" =~ /hello/\n# => 0\n\"hello world\" =~ /bacon/\n# => nil\n\n# Also used in Regexp to match a String\n/hello/ =~ \"hello world\"\n# => 0\n/bacon/ =~ \"hello world\"\n# => nil\n"
     },
     {
         "name": "hat",


### PR DESCRIPTION
Add examples for equalike

```ruby
# Pattern matching
# Used in String to match a Regular Expression (Regexp)
"hello world" =~ /hello/
# => 0
"hello world" =~ /bacon/
# => nil

# Also used in Regexp to match a String
/hello/ =~ "hello world"
# => 0
/bacon/ =~ "hello world"
# => nil
```

and one for threequals
```ruby
# Case match
class Icecream
  attr_accessor :flavour

  def initialize(flavour)
    @flavour = flavour
  end

  def ===(another_icecream)
    @flavour == another_icecream.flavour
  end
end

vanilla_icecream = Icecream.new 'vanilla'

case vanilla_icecream
when (Icecream.new 'chocolate')
  puts "Yikes!"
when (Icecream.new 'cookies and cream')
  puts "Yikes!"
when (Icecream.new 'vanilla')
  puts "Yiiiiis!"
end
# => "Yiiiiis!"
```

References taken from:
http://ruby-doc.org/core-2.2.3/Object.html#method-i-3D-7E
http://ruby-doc.org/core-2.2.3/Regexp.html#method-i-3D-7E
http://ruby-doc.org/core-2.2.0/String.html#method-i-3D-7E
http://ruby-doc.org/core-2.2.3/Object.html#method-i-3D-3D-3D